### PR TITLE
default Gluon Release wieder hinzugefügt

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -113,10 +113,9 @@ GLUON_SITE_PACKAGES += \
         kmod-usb-net-dm9601-ether
 endif
 
-#DEFAULT_GLUON_RELEASE := 2017.1.4+t$(shell date '+%Y%m%d')
+DEFAULT_GLUON_RELEASE := 2017.1.4+t$(shell date '+%Y%m%d')
 
-#GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)
-#GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)
+GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)
 
 #GLUON_BRANCH ?= testing
 #export GLUON_BRANCH


### PR DESCRIPTION
Da das Makefile von gluon immer überprüft ob die variable gesetzt ist würde ich so eine Lösung bevorzugen. Wenn man das dann überschreiben will, kann man das in einem Skript ja machen.
Alternativ muss man das beim manuellen bauen selbst mit angeben. Gefällt mir nicht so gut.

Es sei denn es spricht etwas dagegen es so zu machen?